### PR TITLE
Fix `KnexDriver` throws NODE_ENV

### DIFF
--- a/server/driver/KnexDriver.js
+++ b/server/driver/KnexDriver.js
@@ -21,10 +21,10 @@ module.exports = knex({
     user: getEnvironmentVariable("DATABASE_USERNAME"),
     password: getEnvironmentVariable("DATABASE_PASSWORD"),
     database:
-      getEnvironmentVariable("NODE_ENV") === "test"
+      process.env.NODE_ENV && process.env.NODE_ENV === "test"
         ? getEnvironmentVariable("DATABASE_TEST")
         : getEnvironmentVariable("DATABASE_NAME"),
   },
-  debug: process.env.NODE_ENV.toString() === "dev",
+  debug: process.env.NODE_ENV && process.env.NODE_ENV.toString() === "dev",
   // asyncStackTraces: true,
 });

--- a/server/driver/Table.js
+++ b/server/driver/Table.js
@@ -1,3 +1,4 @@
+"use strict";
 const Tables = {
   Users: "Users",
   Wards: "Wards",


### PR DESCRIPTION
- Fix KnexDriver throws error when not supplying NODE_ENV